### PR TITLE
fixed warning regarding _ vs - when building with colcon and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,43 @@ One other thing to be wary of: this is a ROS/ament Python package, which means t
 
 A launch file and example parameters are provided.
 
+Clone this repo into your ~/dev_ws/src/ folder:
+```
+git clone git@github.com:joshnewans/ball_tracker.git
+```
+
+Preliminary tuning mode (remember to source foxy and workspace):
+```
+ros2 run ball_tracker detect_ball --ros-args -p tuning_mode:=true -r image_in:=camera/image_raw
+```
+rviz2: add `Image` -> `Topic: /image_out`
+
+Record those parameters!
+
+Get detect ball's point measurements:
+```
+ros2 topic echo /detected_ball
+```
+
+3D ball location estimation:
+```
+ros2 run ball_tracker detect_ball_3d
+```
+rviz2: add `Marker` -> `Topic: /ball_3d_marker`
+
+Follow the ball:
+```
+ros2 run ball_tracker follow_ball --ros-args -r cmd_vel:=cmd_vel_tracker
+```
+
+Copy `ball_tracker_params_example.yaml` into your main ros package config folder.
+Rename it to `ball_tracker_params_sim.yaml` with the appropriate tuning parameters.
+
+Then you can launch:
+```
+ros2 launch ball_tracker ball_tracker.launch.py params_file:=src/<main_ros_package_name>/config/ball_tracker_params_sim.yaml enable_3d_track:=true
+```
+
 ## Nodes
 
 TODO Document them

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Thanks very much to Tiziano Fiorenzani for his [ROS 1 tutorial](https://www.yout
 
 One other thing to be wary of: this is a ROS/ament Python package, which means the launch and config files contained will NOT be linked with the `--symlink-install` command for colcon, and will need to be rebuilt after changes.
 
+Remove warning triggers regarding setuptools by downgrading the version:
+`pip install setuptools==58.2.0`
 
 ## Getting started
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/ball_tracker
+script_dir=$base/lib/ball_tracker
 [install]
-install-scripts=$base/lib/ball_tracker
+install_scripts=$base/lib/ball_tracker


### PR DESCRIPTION
1) Added notes based off your video tutorial!

2) Here's the warning message that we can get rid of:
```
Starting >>> ball_tracker
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
```